### PR TITLE
Add occupiedSince property to ElectricityStationOccupancyResponse and remove attendees from ElectricityStationsOccupancyResponse

### DIFF
--- a/lsis-openapi.yaml
+++ b/lsis-openapi.yaml
@@ -33,8 +33,6 @@ info:
 
     **Version 0.0.12**
     - Add missing `occupiedSince` property to `ElectricityStationOccupancyResponse`
-    - Remove `attendees` from `ElectricityStationsOccupancyResponse` schema instead of mentioning it in the 
-      `occupancy` endpoint description.
   contact:
     name: LSIS Support
     email: support@landelijksis.net
@@ -86,7 +84,8 @@ paths:
     get:
       summary: Retrieve occupancy of all electricity stations
       description: |
-        REST/JSON API-endpoint for global attendance on all caller visible stations.
+        REST/JSON API-endpoint for global attendance on all caller visible stations. 
+        Note that attendees are only available for individual stations.
       operationId: getAllStationsOccupancy
       parameters:
         - name: occupied
@@ -369,33 +368,7 @@ components:
         data:
           type: array
           items:
-            type: object
-            required: [id, occupied, externalIds]
-            additionalProperties: false
-            properties:
-              id:
-                type: string
-                description: Station ID
-              occupied:
-                type: boolean
-                description: Whether the station is occupied
-              occupiedSince:
-                type: string
-                format: date-time
-                description: Date and time the station became occupied.
-                  <p><b>Note:</b> This value is only required when the `occupied` is true.</p>
-              externalIds:
-                type: array
-                items:
-                  type: object
-                  required: [sysop, refId]
-                  properties:
-                    sysop:
-                      type: string
-                      description: Tenant identifier of the grid operator
-                    refId:
-                      type: string
-                      description: Reference identifier of the station at the grid operator
+            $ref: "#/components/schemas/ElectricityStationOccupancyResponse"
         responseMetadata:
           type: object
           properties:
@@ -413,6 +386,15 @@ components:
             externalIds:
               - sysop: A123-4563-4B13
                 refId: "000000002"
+            attendees:
+              - userId: GUID-2733
+                fullName: Conny ter Plaatse
+                phoneNumber: "31677777777"
+                isContactPerson: true
+                guestOf: GUID-bab3
+                registeredBy: GUID-caf3
+                attendingSince: "2024-04-04T10:31:00Z"
+                company: Stedin
         responseMetadata:
           nextCursor: "dXNlcjpVMEc5V0ZYTlo="
 

--- a/lsis-openapi.yaml
+++ b/lsis-openapi.yaml
@@ -33,6 +33,8 @@ info:
 
     **Version 0.0.12**
     - Add missing `occupiedSince` property to `ElectricityStationOccupancyResponse`
+    - Remove `attendees` from `ElectricityStationsOccupancyResponse` schema instead of mentioning it in the 
+      `occupancy` endpoint description.
   contact:
     name: LSIS Support
     email: support@landelijksis.net
@@ -84,8 +86,7 @@ paths:
     get:
       summary: Retrieve occupancy of all electricity stations
       description: |
-        REST/JSON API-endpoint for global attendance on all caller visible stations. 
-        Note that attendees are only available for individual stations.
+        REST/JSON API-endpoint for global attendance on all caller visible stations.
       operationId: getAllStationsOccupancy
       parameters:
         - name: occupied
@@ -368,7 +369,33 @@ components:
         data:
           type: array
           items:
-            $ref: "#/components/schemas/ElectricityStationOccupancyResponse"
+            type: object
+            required: [id, occupied, externalIds]
+            additionalProperties: false
+            properties:
+              id:
+                type: string
+                description: Station ID
+              occupied:
+                type: boolean
+                description: Whether the station is occupied
+              occupiedSince:
+                type: string
+                format: date-time
+                description: Date and time the station became occupied.
+                  <p><b>Note:</b> This value is only required when the `occupied` is true.</p>
+              externalIds:
+                type: array
+                items:
+                  type: object
+                  required: [sysop, refId]
+                  properties:
+                    sysop:
+                      type: string
+                      description: Tenant identifier of the grid operator
+                    refId:
+                      type: string
+                      description: Reference identifier of the station at the grid operator
         responseMetadata:
           type: object
           properties:
@@ -386,15 +413,6 @@ components:
             externalIds:
               - sysop: A123-4563-4B13
                 refId: "000000002"
-            attendees:
-              - userId: GUID-2733
-                fullName: Conny ter Plaatse
-                phoneNumber: "31677777777"
-                isContactPerson: true
-                guestOf: GUID-bab3
-                registeredBy: GUID-caf3
-                attendingSince: "2024-04-04T10:31:00Z"
-                company: Stedin
         responseMetadata:
           nextCursor: "dXNlcjpVMEc5V0ZYTlo="
 

--- a/lsis-openapi.yaml
+++ b/lsis-openapi.yaml
@@ -33,6 +33,8 @@ info:
 
     **Version 0.0.12**
     - Add missing `occupiedSince` property to `ElectricityStationOccupancyResponse`
+    - The `attendees` array should now be populated when the station is occupied and when retrieving 
+      the occupancies of all stations via the `/occupancy` endpoint.
   contact:
     name: LSIS Support
     email: support@landelijksis.net
@@ -84,8 +86,7 @@ paths:
     get:
       summary: Retrieve occupancy of all electricity stations
       description: |
-        REST/JSON API-endpoint for global attendance on all caller visible stations. 
-        Note that attendees are only available for individual stations.
+        REST/JSON API-endpoint for global attendance on all caller visible stations.
       operationId: getAllStationsOccupancy
       parameters:
         - name: occupied

--- a/lsis-openapi.yaml
+++ b/lsis-openapi.yaml
@@ -7,7 +7,7 @@
 openapi: 3.0.3
 info:
   title: LSIS API (REST)
-  version: 0.0.11
+  version: 0.0.12
   description: |
     This API enables on-demand querying of station occupancy through RESTful services.
 
@@ -30,6 +30,9 @@ info:
     - types of error response properties are made more explicit.
     - Change urls to be compliant with NBility model.
     - Change securitySchemes to oAuth2. (The tokenUrl and refreshUrl are unknown at this moment).
+
+    **Version 0.0.12**
+    - Add missing `occupiedSince` property to `ElectricityStationOccupancyResponse`
   contact:
     name: LSIS Support
     email: support@landelijksis.net
@@ -279,6 +282,11 @@ components:
             occupied:
               type: boolean
               description: Whether the station is occupied
+            occupiedSince:
+              type: string
+              format: date-time
+              description: Date and time the station became occupied.
+                <p><b>Note:</b> This value is only required when the `occupied` is true.</p>
             externalIds:
               type: array
               items:


### PR DESCRIPTION
- The `occupiedSince` property was added to the example, but not to the properties in the specification. This is now rectified.
- The `attendees` property is now removed from the `ElectricityStationsOccupancyResponse` instead of mentioning it in the `occupancy` description.